### PR TITLE
Build scripts for Linux distributions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "start": "cross-env NODE_ENV=production electron ./",
     "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.js",
     "dev": "concurrently --kill-others \"npm run hot-server\" \"npm run start-hot\"",
-    "release-mac": "npm run build && build -m"
+    "release-mac": "npm run build && build -m",
+    "release-linux": "npm run build && build -l",
+    "release-linux-deb": "npm run build && build -l deb",
+    "release-linux-rpm": "npm run build && build -l rpm",
+    "release-linux-pacman": "npm run build && build -l pacman",
+    "release-linux-all": "npm run build && build -l deb rpm pacman"
   },
   "build": {
     "productName": "AstroGif",


### PR DESCRIPTION
Once #11 is resolved, building releases for Linux (on Linux and macOS at least) should work following [this guide](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build).

In this PR I've added build scripts for Linux unpacked, .deb (Debian based), .rpm (RedHat based), and pacman (Arch based) distributions. Though further scripts for be needed to build the app for different architectures (e.g. 32-bit deb built on a 64-bit system).

The packaged deb installs and runs perfectly on Elementary/Ubuntu 16.04!

![](http://media0.giphy.com/media/daeKl3P4SissU/giphy.gif)