### PR TITLE
Make eslint lint again

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint": "^3.12.2",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-import-resolver-webpack": "^0.7.1",
+    "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "electron-packager": "^5.1.0",
     "electron-prebuilt": "^1.4.13",
     "eslint": "^3.12.2",
-    "eslint-config-airbnb": "^13.0.0",
+    "eslint-config-airbnb": "^14.0.0",
     "eslint-import-resolver-webpack": "^0.7.1",
     "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
Adds the missing `eslint-plugin-babel` package and updates `eslint-config-airbnb` to the latest release (14.0.0) to fix a config error.