### PR TITLE
Focus window when shortcut is pressed

### DIFF
--- a/main.js
+++ b/main.js
@@ -106,7 +106,12 @@ ipcMain.on('resetHeight', () => {
 ipcMain.on('shortcut', (event, shortcut) => {
   globalShortcut.unregisterAll();
   globalShortcut.register(shortcut, () => {
-    mb.window.isVisible() ? mb.hideWindow() : mb.showWindow()
+    if (mb.window.isVisible()) {
+      mb.hideWindow();
+    } else {
+      mb.showWindow();
+      mb.window.focus();
+    }
   });
 });
 


### PR DESCRIPTION
On Linux (at least on GNOME / Pantheon desktops), opening AstroGif via the hotkey tends to leave the app stuck behind whichever window is currently focused, meaning you have to alt+tab to get to AstroGif after opening it.

Calling `mb.window.focus()` forces the window to be brought to the front and focused. I am not sure what side effects (if any) this would have, including on macOS and Windows.

![](http://media2.giphy.com/media/l46CsTPetihC1rX9K/giphy.gif)